### PR TITLE
Apply custom Panopto iOS logic to latest stable version of original repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Panopto/react-native-background-upload
+
+This is a Panopto-specific fork of the Vydia/react-native-background-upload project that adds the following functionality for iOS:
+
+1. responseHeaders are included in the upload completion event and exposed to TypeScript
+2. Exposes setCompletionHandlerWithIdentifier to be called from AppDelegate.mm so that upload completion can happen in the background
+3. Exposes resumeTasks to be called from AppDelegate.mm to work around a bug in NSURLSession (https://developer.apple.com/forums/thread/77666?page=2)
+
+Android code is not modified and can use the latest from the original repository.
+
 # react-native-background-upload [![npm version](https://badge.fury.io/js/react-native-background-upload.svg)](https://badge.fury.io/js/react-native-background-upload) ![GitHub Actions status](https://github.com/Vydia/react-native-background-upload/workflows/Test%20iOS%20Example%20App/badge.svg) ![GitHub Actions status](https://github.com/Vydia/react-native-background-upload/workflows/Test%20Android%20Example%20App/badge.svg) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 The only React Native http post file uploader with android and iOS background support.  If you are uploading large files like videos, use this so your users can background your app during a long upload.

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ declare module "react-native-background-upload" {
 
         responseCode: number
         responseBody: string
+        responseHeaders: { [key: string]: string }
     }
     export type FileInfo = {
         name: string

--- a/ios/VydiaRNFileUploader.h
+++ b/ios/VydiaRNFileUploader.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <MobileCoreServices/MobileCoreServices.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
+
+@interface VydiaRNFileUploader : RCTEventEmitter <RCTBridgeModule, NSURLSessionTaskDelegate>
++ (void)setCompletionHandlerWithIdentifier: (NSString *)identifier completionHandler: (void (^)())completionHandler;
++ (void)resumeTasks;
+@end


### PR DESCRIPTION
Description:

This applies Panopto's custom background upload logic to the iOS portion of the react-native-background-upload project. This is the same code that has been working since we implemented the feature, but consolidated and polished for a clean diff against the latest react-native-background-upload code. This is intended to allow us to easily pull in the latest Android changes (the Android code doesn't have any custom modification) while merging in any iOS changes that don't conflict with our custom additions.

I also updated the README to keep track of the custom changes we've made, so we don't lose track of the motivation for them.

Testing:

Manually tested background upload in react-native-mobile on real iOS and Android devices
