### PR TITLE
Apply autoClear setting to cancelled and error notifications as well as completion

### DIFF
--- a/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
+++ b/android/src/main/java/com/vydia/RNUploader/UploaderModule.kt
@@ -218,11 +218,13 @@ class UploaderModule(val reactContext: ReactApplicationContext) : ReactContextBa
                 ),
                 error = UploadNotificationStatusConfig(
                         title = if (notification.hasKey("onErrorTitle")) notification.getString("onErrorTitle")!! else "",
-                        message = if (notification.hasKey("onErrorMessage")) notification.getString("onErrorMessage")!! else ""
+                        message = if (notification.hasKey("onErrorMessage")) notification.getString("onErrorMessage")!! else "",
+                        autoClear = notification.hasKey("autoClear") && notification.getBoolean("autoClear")
                 ),
                 cancelled = UploadNotificationStatusConfig(
                         title = if (notification.hasKey("onCancelledTitle")) notification.getString("onCancelledTitle")!! else "",
-                        message = if (notification.hasKey("onCancelledMessage")) notification.getString("onCancelledMessage")!! else ""
+                        message = if (notification.hasKey("onCancelledMessage")) notification.getString("onCancelledMessage")!! else "",
+                        autoClear = notification.hasKey("autoClear") && notification.getBoolean("autoClear")
                 )
         )
         request.setNotificationConfig { _, _ ->


### PR DESCRIPTION
This patches the Android native code to apply autoClear notification setting to cancelled and error notifications as well as completion. This was part of the previous behavior and was missed during the refactor to upgrade the okhttp library.