### PR TITLE
Update plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.6.0'
+        kotlinVersion = '1.8.20'
         buildToolsVersion = '29.0.2'
         compileSdkVersion = 29
         targetSdkVersion = 29

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
         kotlinVersion = '1.8.20'
-        buildToolsVersion = '29.0.2'
-        compileSdkVersion = 29
-        targetSdkVersion = 29
-        minSdkVersion = 18
+        buildToolsVersion = '31.0.0'
+        compileSdkVersion = 33
+        targetSdkVersion = 33
+        minSdkVersion = 24
     }
     ext.detoxKotlinVersion = ext.kotlinVersion
 
@@ -22,9 +22,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 33
+def DEFAULT_BUILD_TOOLS_VERSION = "31.0.0"
+def DEFAULT_TARGET_SDK_VERSION = 33
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
-        kotlinVersion = '1.8.20'
-        buildToolsVersion = '31.0.0'
-        compileSdkVersion = 33
-        targetSdkVersion = 33
-        minSdkVersion = 24
+        kotlinVersion = '1.6.0'
+        buildToolsVersion = '29.0.2'
+        compileSdkVersion = 29
+        targetSdkVersion = 29
+        minSdkVersion = 18
     }
     ext.detoxKotlinVersion = ext.kotlinVersion
 
@@ -20,11 +20,11 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
-def DEFAULT_COMPILE_SDK_VERSION = 33
-def DEFAULT_BUILD_TOOLS_VERSION = "31.0.0"
-def DEFAULT_TARGET_SDK_VERSION = 33
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 28
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback


### PR DESCRIPTION
# Summary
Change deprecated `kotlin-android-extensions` to `kotlin-parcelize` plugin to fix build error after Expo and React Native updates made on https://github.com/Panopto/react-native-mobile/pull/444.